### PR TITLE
Fixing playback not starting when video source is set in video tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Quality picker dependency in `package.json` and initialization in test page. It's usage was removed in modifications, required for the Brightcove plugin.
 
 ## [0.2.3] - 2016-09-27
-## Changed
+### Changed
 - Modifications required to use with Brightcove plugin: Hls.js is initialized lazy, only at point when media is requesting data. This way we can be sure that plugin is initialized already and our player instance carries P2P config information.
 
-## Added
+### Added
 - Publish to NPM
 
 ## [0.1.4] - 2016-08-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Dev]
 
 ## [Unreleased]
+### Fixed
+- Broken playback when video source was set in video tag. It was caused by source handler disposal, triggered by video.js. See comments in `lib/videojs5-hlsjs-source-handler.js` for detailed explanation.
+
+### Removed
+- Quality picker dependency in `package.json` and initialization in test page. It's usage was removed in modifications, required for the Brightcove plugin.
 
 ## [0.2.3] - 2016-09-27
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Dev]
 
 ## [Unreleased]
+
+## [0.2.3] - 2016-09-27
 ## Changed
 - Modifications required to use with Brightcove plugin: Hls.js is initialized lazy, only at point when media is requesting data. This way we can be sure that plugin is initialized already and our player instance carries P2P config information.
 

--- a/debug.html
+++ b/debug.html
@@ -14,7 +14,7 @@
 
 <body>
 
-    <video id="example-video" width="600" height="300" class="video-js vjs-default-skin" controls>
+    <video id="example-video" width="600" height="300" class="video-js vjs-default-skin" controls muted>
         <!-- <source src="http://akamai.streamroot.edgesuite.net/vodorigin/tos.mp4/playlist.m3u8" type="application/x-mpegURL"/> -->
         <!-- <source src="http://playertest.longtailvideo.com/adaptive/oceans_aes/oceans_aes.m3u8" type="application/x-mpegURL"/> -->
         <source src="http://sample.vodobox.net/skate_phantom_flex_4k/skate_phantom_flex_4k.m3u8" type="application/x-mpegURL"/>

--- a/debug.html
+++ b/debug.html
@@ -33,8 +33,6 @@
             }
         };
         var player = videojs('example-video', options);
-
-        player.qualityPickerPlugin();
     </script>
 
 </body>

--- a/debug.html
+++ b/debug.html
@@ -26,6 +26,9 @@
             html5: {
                 hlsjsConfig: {
                     debug: true
+                },
+                p2pConfig: {
+                    streamrootKey: 'ry-tguzre2t'
                 }
             }
         };

--- a/lib/videojs5-hlsjs-source-handler.js
+++ b/lib/videojs5-hlsjs-source-handler.js
@@ -32,7 +32,6 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
         });
 
         function initialize() {
-            console.info('initialize. firstTime=', firstTime);
             if (firstTime) {
                 _video.addEventListener('waiting', _onWaitingForData);
             } else {

--- a/lib/videojs5-hlsjs-source-handler.js
+++ b/lib/videojs5-hlsjs-source-handler.js
@@ -1,6 +1,6 @@
 var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
 
-    var firstTime = true;
+    var firstTimeInit = true;
     function StreamrootProviderHLS (source, tech) {
         tech.name_ = 'streamrootHLS';
 
@@ -32,7 +32,7 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
         });
 
         function initialize() {
-            if (firstTime) {
+            if (firstTimeInit) {
                 _video.addEventListener('waiting', _onWaitingForData);
             } else {
                 _onWaitingForData();
@@ -48,8 +48,8 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
             _video.removeEventListener('waiting', _onWaitingForData);
             _hls.destroy();
 
-            if (firstTime) {
-                firstTime = false;
+            if (firstTimeInit) {
+                firstTimeInit = false;
                 tech.setSource(source);
             }
         };

--- a/lib/videojs5-hlsjs-source-handler.js
+++ b/lib/videojs5-hlsjs-source-handler.js
@@ -31,6 +31,20 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
             console.error("MEDIA_ERROR: ", errorTxt);
         });
 
+        // Some context on what's happening here:
+        // Video.js expects video source to be set by using tech's `setSource` method.
+        // If this mechanism is bypassed, Video.js disposes the source handler and stops playback.
+        // Video.js detects bypassing by listening to `loadstart` event of video tag.
+        // And if this event is caught 2 times during playback of one video,
+        // video.js thinks that video source was changed in a wrong way and
+        // it disposes the source handler.
+        // Due to the fact that hls.js is initialized after `waiting` video tag event
+        // (to avoid manifest (re)download and undesired segment prefetching),
+        // `loadstart` event fires 2 times if video source is set in video tag.
+        // This causes source handler disposal and brakes playback.
+        // `firstTimeInit` was introduced as a workaround for this situation.
+        // It's used to reset tech's source if source handler was disposed for the 1st
+        // time, which will cause playback start.
         function initialize() {
             if (firstTimeInit) {
                 _video.addEventListener('waiting', _onWaitingForData);
@@ -44,6 +58,7 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
             return _duration || _video.duration || 0;
         };
 
+        // See comment for `initialize` method.
         this.dispose = function () {
             _video.removeEventListener('waiting', _onWaitingForData);
             _hls.destroy();

--- a/lib/videojs5-hlsjs-source-handler.js
+++ b/lib/videojs5-hlsjs-source-handler.js
@@ -1,4 +1,6 @@
 var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
+
+    var firstTime = true;
     function StreamrootProviderHLS (source, tech) {
         tech.name_ = 'streamrootHLS';
 
@@ -30,7 +32,13 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
         });
 
         function initialize() {
-            _video.addEventListener('waiting', _onWaitingForData);
+            console.info('initialize. firstTime=', firstTime);
+            if (firstTime) {
+                _video.addEventListener('waiting', _onWaitingForData);
+            } else {
+                _onWaitingForData();
+                _video.play();
+            }
         }
 
         this.duration = function () {
@@ -40,6 +48,11 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
         this.dispose = function () {
             _video.removeEventListener('waiting', _onWaitingForData);
             _hls.destroy();
+
+            if (firstTime) {
+                firstTime = false;
+                tech.setSource(source);
+            }
         };
 
         function switchQuality(qualityId, trackType) {

--- a/lib/videojs5-hlsjs-source-handler.js
+++ b/lib/videojs5-hlsjs-source-handler.js
@@ -162,7 +162,7 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
 
         function _initMedia() {
             // initialize the loading routine of the media-engine
-            _hls.loadSource(source.src);  
+            _hls.loadSource(source.src);
         }
 
         function _initHlsjs() {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "streamroot-hlsjs-p2p-bundle": "^3.6.4",
-    "videojs-quality-picker": "^0.0.3"
+    "streamroot-hlsjs-p2p-bundle": "^3.6.4"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/131971287

**The bug**
Playback doesn't start if video source(for example manifest url) was set inside video tag.

**What caused the bug**
Video.js expects video source to be set by using tech's `setSource` method. If this mechanism is bypassed, Video.js disposes the source handler and stops playback. Video.js detects bypassing by listening to `loadstart` event of video tag. And if this event is caught 2 times during playback of one video, Video.js thinks that video source was changed in a wrong way and it disposes the source handler.

Due to the fact that hls.js is initialized after `waiting` video tag event (to avoid manifest (re)download and undesired segment prefetching), `loadstart` event fires 2 times if video source is set in video tag. This causes source handler disposal and brakes playback start.

**Solution**
Check if source handler was instantiated only once in its `dispose` method, and if so, set tech's source again and call `video.play` on video tag to trigger playback start. `firstTimeInit` variable was introduced to check, if source handler was instantiated only once.