### PR TITLE
copy hls.js config before passing it to hls.js 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Dev]
 
 ## [Unreleased]
+### Fixed
+- copy hls.js config before passing it to hls.js (it assigns properties from default conf in place)
 
 ## [0.2.20] - 2016-12-08
 ### Updated

--- a/lib/videojs5-hlsjs-source-handler.js
+++ b/lib/videojs5-hlsjs-source-handler.js
@@ -1,3 +1,5 @@
+var assign = require('lodash.assign');
+
 var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
 
     function StreamrootProviderHLS (source, tech) {
@@ -143,7 +145,8 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
         }
 
         function _initHlsjs() {
-            var hlsjsConfig = tech.options_.hlsjsConfig || {};
+            // Use underscore to copy hlsjsConfig. hls.js will add defaults in place in this object, and they still be there if we load a second video. This can cause bugs because of invalid config failfasts
+            var hlsjsConfig = assign({}, tech.options_.hlsjsConfig);
             var p2pConfig = tech.options_.p2pConfig || {};
 
             if (['', 'auto'].indexOf(_video.preload) === -1 && !_video.autoplay && hlsjsConfig.autoStartLoad === undefined) {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
+    "lodash.assign": "^4.2.0",
     "streamroot-hlsjs-p2p-bundle": "^4.0.0"
   },
   "license": "MIT",


### PR DESCRIPTION
hls.js assigns properties from default conf directly in the config object passed in its constructor